### PR TITLE
Fix invalid JSON in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ See [`setup.py`](https://github.com/OpenVoiceOS/ovos-tts-plugin-mimic3/blob/mast
   "tts": {
     "module": "ovos-tts-plugin-mimic3",
     "ovos-tts-plugin-mimic3": {
-      "voice": "en_UK/apope_low",
+      "voice": "en_UK/apope_low"
     }
   }
 ```


### PR DESCRIPTION
The json configuration in the readme will fail to work because of a trailing comma. This PR fixes that.